### PR TITLE
Fixed Typo and disabled wargaming

### DIFF
--- a/bind/named.conf.local.lan-cache
+++ b/bind/named.conf.local.lan-cache
@@ -7,4 +7,4 @@ include "/etc/bind/named.conf.local.sony";
 include "/etc/bind/named.conf.local.tera";
 include "/etc/bind/named.conf.local.microsoft";
 #include "/etc/bind/named.conf.local.gog"; #Commented because HTTPS ATM
-include "/etc/bind/named.conf.local.wargaming";
+#include "/etc/bind/named.conf.local.wargaming";

--- a/bind/named.conf.local.origin
+++ b/bind/named.conf.local.origin
@@ -12,9 +12,9 @@ zone "origin-a.akamaihd.net." IN {
         file "/etc/bind/db.lancache.origin";
 };
 
-zone "lvlt.cdn.ea.com."
+zone "lvlt.cdn.ea.com." IN {
         type master;
-        file"file "/etc/bind/db.lancache.origin";
+        file "/etc/bind/db.lancache.origin";
 };
 
 zone "origin-b.akamaihd.net." IN {


### PR DESCRIPTION
There was a Typo in bind/named.conf.local.origin that I fixed.

I also diasabled wargaming in bind. Wargaming switched to an torrent only distribution for there files.
