### PR TITLE
Update unbound.conf

### DIFF
--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -8,170 +8,169 @@ server:
     do-daemonize: yes
     do-ip6: no
     access-control: 0.0.0.0/0 allow
-    log-queries: yes
+    log-queries: no
     hide-version: yes
     identity: "lancache DNS"
-    harden-short-bufsize: yes
+    harden-short-bufsize: no
     harden-large-queries: no
     harden-glue: yes
+    rrset-cache-size: 256m
+    msg-cache-size: 128m
 
     ## LANcache config ##
     ## Arena networks °|-lc-host-vint:10
         local-zone: "arenanetworks.com." redirect
-        local-data: "arenanetworks.com. A lc-host-arena"
+        local-data: "arenanetworks.com. 600 IN A lc-host-arena"
 
     ## Blizzard °|-lc-host-vint:3
         local-zone: "edgesuite.net." transparent
         local-zone: "dist.blizzard.com." redirect
-        local-data: "dist.blizzard.com. A lc-host-blizzard"
+        local-data: "dist.blizzard.com. 600 IN A lc-host-blizzard"
         local-zone: "llnw.blizzard.com." redirect
-        local-data: "llnw.blizzard.com. A lc-host-blizzard"
+        local-data: "llnw.blizzard.com. 600 IN A lc-host-blizzard"
         local-zone: "level3.blizzard.com." redirect
-        local-data: "level3.blizzard.com. A lc-host-blizzard"
+        local-data: "level3.blizzard.com. 600 IN A lc-host-blizzard"
         local-zone: "dist.blizzard.com.edgesuite.net." redirect
-        local-data: "dist.blizzard.com.edgesuite.net. A lc-host-blizzard"
+        local-data: "dist.blizzard.com.edgesuite.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist1-a.akamaihd.net." redirect
-        local-data: "blzddist1-a.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist1-a.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist2-a.akamaihd.net." redirect
-        local-data: "blzddist2-a.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist2-a.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist1-b.akamaihd.net." redirect
-        local-data: "blzddist1-b.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist1-b.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist2-b.akamaihd.net." redirect
-        local-data: "blzddist2-b.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist2-b.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist3-a.akamaihd.net." redirect
-        local-data: "blzddist3-a.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist3-a.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blzddist3-b.akamaihd.net." redirect
-        local-data: "blzddist3-b.akamaihd.net. A lc-host-blizzard"
+        local-data: "blzddist3-b.akamaihd.net. 600 IN A lc-host-blizzard"
         local-zone: "blizzard.vo.llnwd.net." redirect
-        local-data: "blizzard.vo.llnwd.net. A lc-host-blizzard"
+        local-data: "blizzard.vo.llnwd.net. 600 IN A lc-host-blizzard"
         local-zone: "edge.blizzard.top.comcast.net." redirect
-        local-data: "edge.blizzard.top.comcast.net. A lc-host-blizzard"
+        local-data: "edge.blizzard.top.comcast.net. 600 IN A lc-host-blizzard"
         
-        
-
-
     ## GOG °|-lc-host-vint:9
         local-zone: "cdn.gog.com." redirect
-        local-data: "cdn.gog.com. A lc-host-gog"
+        local-data: "cdn.gog.com. 600 IN A lc-host-gog"
         local-zone: "wpc.11df.deltacdn.net." redirect
-        local-data: "wpc.11df.deltacdn.net. A lc-host-gog"
+        local-data: "wpc.11df.deltacdn.net. 600 IN A lc-host-gog"
         local-zone: "11df-eu-lb.wpc.edgecastcdn.net." redirect
-        local-data: "11df-eu-lb.wpc.edgecastcdn.net. A lc-host-gog"
+        local-data: "11df-eu-lb.wpc.edgecastcdn.net. 600 IN A lc-host-gog"
         local-zone: "11df-eu-lb.apr-11df.edgecastdns.net." redirect
-        local-data: "11df-eu-lb.apr-11df.edgecastdns.net. A lc-host-gog"
+        local-data: "11df-eu-lb.apr-11df.edgecastdns.net. 600 IN A lc-host-gog"
 
     ## Hirez °|-lc-host-vint:4
         local-zone: "hirez.http.internapcdn.net." redirect
-        local-data: "hirez.http.internapcdn.net. A lc-host-hirez"
+        local-data: "hirez.http.internapcdn.net. 600 IN A lc-host-hirez"
 
     ## Microsoft Windows Updates °|-lc-host-vint:7
         local-zone: "windowsupdate.com." redirect
-        local-data: "windowsupdate.com. A lc-host-microsoft"
+        local-data: "windowsupdate.com. 600 IN A lc-host-microsoft"
         local-zone: "dlassets.xboxlive.com." redirect
-        local-data: "dlassets.xboxlive.com. A lc-host-microsoft"
+        local-data: "dlassets.xboxlive.com. 600 IN A lc-host-microsoft"
         local-zone: "msxbassets.loris.llnwd.net." redirect
-        local-data: "msxbassets.loris.llnwd.net. A lc-host-microsoft"
+        local-data: "msxbassets.loris.llnwd.net. 600 IN A lc-host-microsoft"
         local-zone: "xboxone.loris.llnwd.net." redirect
-        local-data: "xboxone.loris.llnwd.net. A lc-host-microsoft"        
+        local-data: "xboxone.loris.llnwd.net. 600 IN A lc-host-microsoft"        
         local-zone: "xboxone.vo.llnwd.net." redirect
-        local-data: "xboxone.vo.llnwd.net. A lc-host-microsoft"
+        local-data: "xboxone.vo.llnwd.net. 600 IN A lc-host-microsoft"
         local-zone: "images-eds.xboxlive.com." redirect
-        local-data: "images-eds.xboxlive.com. A lc-host-microsoft"        
+        local-data: "images-eds.xboxlive.com. 600 IN A lc-host-microsoft"        
         local-zone: "xbox-mbr.xboxlive.com." redirect
-        local-data: "xbox-mbr.xboxlive.com. A lc-host-microsoft"
+        local-data: "xbox-mbr.xboxlive.com. 600 IN A lc-host-microsoft"
         local-zone: "assets1.xboxlive.com.nsatc.net." redirect
-        local-data: "assets1.xboxlive.com.nsatc.net. A lc-host-microsoft"
+        local-data: "assets1.xboxlive.com.nsatc.net. 600 IN A lc-host-microsoft"
         local-zone: "assets1.xboxlive.com." redirect
-        local-data: "assets1.xboxlive.com. A lc-host-microsoft"        
+        local-data: "assets1.xboxlive.com. 600 IN A lc-host-microsoft"        
       
     ## Origin °|-lc-host-vint:5
         local-zone: "ea.com." transparent
         local-zone: "akamai.cdn.ea.com." redirect
-        local-data: "akamai.cdn.ea.com. A lc-host-origin"
+        local-data: "akamai.cdn.ea.com. 600 IN A lc-host-origin"
         local-zone: "download.origin.com." redirect
-        local-data: "download.origin.com. A lc-host-origin"
+        local-data: "download.origin.com. 600 IN A lc-host-origin"
         local-zone: "origin-a.akamaihd.net." redirect
-        local-data: "origin-a.akamaihd.net. A lc-host-origin"
+        local-data: "origin-a.akamaihd.net. 600 IN A lc-host-origin"
         local-zone: "lvlt.cdn.ea.com." redirect
-        local-data: "lvlt.cdn.ea.com. A lc-host-origin"
+        local-data: "lvlt.cdn.ea.com. 600 IN A lc-host-origin"
         local-zone: "origin-b.akamaihd.net." redirect
-        local-data: "origin-b.akamaihd.net. A lc-host-origin"
+        local-data: "origin-b.akamaihd.net. 600 IN A lc-host-origin"
 
     ## Riot Games °|-lc-host-vint:2
         local-zone: "riotgames.com." transparent
         local-zone: "l3cdn.riotgames.com." redirect
-        local-data: "l3cdn.riotgames.com. A lc-host-riot"
+        local-data: "l3cdn.riotgames.com. 600 IN A lc-host-riot"
         local-zone: "riotgamespatcher-a.akamaihd.net." redirect
-        local-data: "riotgamespatcher-a.akamaihd.net. A lc-host-riot"
+        local-data: "riotgamespatcher-a.akamaihd.net. 600 IN A lc-host-riot"
         local-zone: "riotgamespatcher-a.akamaihd.net.edgesuite.net." redirect
-        local-data: "riotgamespatcher-a.akamaihd.net.edgesuite.net. A lc-host-riot"
+        local-data: "riotgamespatcher-a.akamaihd.net.edgesuite.net. 600 IN A lc-host-riot"
         local-zone: "riotgamespatcher-b.akamaihd.net." redirect
-        local-data: "riotgamespatcher-b.akamaihd.net. A lc-host-riot"
+        local-data: "riotgamespatcher-b.akamaihd.net. 600 IN A lc-host-riot"
         local-zone: "riotgamespatcher-b.akamaihd.net.edgesuite.net." redirect
-        local-data: "riotgamespatcher-b.akamaihd.net.edgesuite.net. A lc-host-riot"
+        local-data: "riotgamespatcher-b.akamaihd.net.edgesuite.net. 600 IN A lc-host-riot"
         local-zone: "worldwide.l3cdn.riotgames.com." redirect
-        local-data: "worldwide.l3cdn.riotgames.com. A lc-host-riot" 
+        local-data: "worldwide.l3cdn.riotgames.com. 600 IN A lc-host-riot" 
 
     ## Sony °|-lc-host-vint:6
         local-zone: "sony.com." transparent
         local-zone: "pls.patch.station.sony.com." redirect
-        local-data: "pls.patch.station.sony.com. A lc-host-sony"
+        local-data: "pls.patch.station.sony.com. 600 IN A lc-host-sony"
 
     ## Steam °|-lc-host-vint:1
         local-zone: "steampowered.com." transparent
         local-zone: "client-download.steampowered.com." redirect
-        local-data: "client-download.steampowered.com. A lc-host-steam"
+        local-data: "client-download.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content1.steampowered.com." redirect
-        local-data: "content1.steampowered.com. A lc-host-steam"
+        local-data: "content1.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content2.steampowered.com." redirect
-        local-data: "content2.steampowered.com. A lc-host-steam"
+        local-data: "content2.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content3.steampowered.com." redirect
-        local-data: "content3.steampowered.com. A lc-host-steam"
+        local-data: "content3.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content4.steampowered.com." redirect
-        local-data: "content4.steampowered.com. A lc-host-steam"
+        local-data: "content4.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content5.steampowered.com." redirect
-        local-data: "content5.steampowered.com. A lc-host-steam"
+        local-data: "content5.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content6.steampowered.com." redirect
-        local-data: "content6.steampowered.com. A lc-host-steam"
+        local-data: "content6.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content7.steampowered.com." redirect
-        local-data: "content7.steampowered.com. A lc-host-steam"
+        local-data: "content7.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "content8.steampowered.com." redirect
-        local-data: "content8.steampowered.com. A lc-host-steam"
+        local-data: "content8.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "cs.steampowered.com." redirect
-        local-data: "cs.steampowered.com. A lc-host-steam"
+        local-data: "cs.steampowered.com. 600 IN A lc-host-steam"
         local-zone: "clientconfig.akamai.steamtransparent.com." redirect
-        local-data: "clientconfig.akamai.steamtransparent.com. A lc-host-steam"
+        local-data: "clientconfig.akamai.steamtransparent.com. 600 IN A lc-host-steam"
         local-zone: "hsar.steampowered.com.edgesuite.net." redirect
-        local-data: "hsar.steampowered.com.edgesuite.net. A lc-host-steam"
+        local-data: "hsar.steampowered.com.edgesuite.net. 600 IN A lc-host-steam"
         local-zone: "steamcontent.com." redirect
-        # local-data: "steampipe.steamcontent.com. A lc-host-steam"
-        local-data: "steamcontent.com. A lc-host-steam"
+        # local-data: "steampipe.steamcontent.com. 600 IN A lc-host-steam"
+        local-data: "steamcontent.com. 600 IN A lc-host-steam"
 
     ## Tera °|-lc-host-vint:8
         local-zone: "patch.tera.enmasse-game.com." redirect
-        local-data: "patch.tera.enmasse-game.com. A lc-host-tera"
+        local-data: "patch.tera.enmasse-game.com. 600 IN A lc-host-tera"
 
     ## Uplay °|-lc-host-vint:12
         local-zone: "cdn.ubi.com." redirect
-        local-data: "cdn.ubi.com. A lc-host-uplay"
+        local-data: "cdn.ubi.com. 600 IN A lc-host-uplay"
 
 
     ## Wargaming °|-lc-host-vint:11
         local-zone: "wargaming.net." transparent
         local-zone: "wg.gcdn.co." redirect
-        local-data: "wg.gcdn.co. A lc-host-wargaming"
+        local-data: "wg.gcdn.co. 600 IN A lc-host-wargaming"
         local-zone: "wargaming.net.edgesuite.net." redirect
-        local-data: "wargaming.net.edgesuite.net. A lc-host-wargaming"
+        local-data: "wargaming.net.edgesuite.net. 600 IN A lc-host-wargaming"
         local-zone: "wgusst-na.wargaming.net." redirect
-        local-data: "wgusst-na.wargaming.net. A lc-host-wargaming"
+        local-data: "wgusst-na.wargaming.net. 600 IN A lc-host-wargaming"
         local-zone: "wgusst-eu.wargaming.net." redirect
-        local-data: "wgusst-eu.wargaming.net. A lc-host-wargaming"
+        local-data: "wgusst-eu.wargaming.net. 600 IN A lc-host-wargaming"
         local-zone: "update-v4r4h10x.worldofwarships.com." redirect
-        local-data: "update-v4r4h10x.worldofwarships.com. A lc-host-wargaming"
+        local-data: "update-v4r4h10x.worldofwarships.com. 600 IN A lc-host-wargaming"
         local-zone: "dl2.wargaming.net." redirect
-        local-data: "dl2.wargaming.net. A lc-host-wargaming"
+        local-data: "dl2.wargaming.net. 600 IN A lc-host-wargaming"
         local-zone: "dl-wows-ak.wargaming.net." redirect
-        local-data: "dl-wows-ak.wargaming.net. A lc-host-wargaming"
+        local-data: "dl-wows-ak.wargaming.net. 600 IN A lc-host-wargaming"
 
     forward-zone:
         ## This basicly tells unbound to anything not defined in the above zones to redirect it to Google


### PR DESCRIPTION
- Turned of query logging (unnecessary performance loss)
- Increased query cache, so there are more answers in the cache, faster response to clients less queries out to the Internet
- Turned off harden-short-bufsize, might break things with this one
- Added 600 second TTL to all LANCache Records.  Just in case  you need to change IP's or turn off caching during the event for some reason.  You don't want clients with the Unbound default 3600 (1 hour) TTL records cached for that long.