### PR TITLE
Fixes for Microsoft/Arena Networks and Set Worker Processes to Auto

### DIFF
--- a/conf/lancache/resolver
+++ b/conf/lancache/resolver
@@ -1,2 +1,2 @@
 # Google and Level3's public DNS servers
-resolver 8.8.8.8 4.2.2.2;
+resolver 8.8.8.8 4.2.2.2 ipv6=off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -21,7 +21,7 @@
 #
 #
 user lancache;
-worker_processes  8;
+worker_processes  auto;
 
 error_log  logs/error.log;
 error_log  logs/error.log  notice;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -50,7 +50,7 @@ http {
     log_format keys_range '[$time_local] - REQUEST="$server_name$request_uri" - KEY="$server_name$uri $http_range" - CACHE="$upstream_cache_status"';
     log_format keys_slice '[$time_local] - REQUEST="$server_name$request_uri" - KEY="$server_name$uri $slice_range" - CACHE="$upstream_cache_status"';
 	
-    resolver 8.8.8.8;
+    resolver 8.8.8.8 4.2.2.2 ipv6=off;
     resolver_timeout 5s;
 	include lancache/caches;
 	include vhosts-enabled/*.conf;

--- a/conf/vhosts-enabled/lancache-arenanetworks.conf
+++ b/conf/vhosts-enabled/lancache-arenanetworks.conf
@@ -1,7 +1,7 @@
 server {
 	listen lancache-arenanetworks deferred default;
 	server_name arenanetworks _;
-	access_log /srv/lancache/logs/Access/arenanetworkslog main buffer=128k flush=1m;
+	access_log /srv/lancache/logs/Access/arenanetworks.log main buffer=128k flush=1m;
 	access_log /srv/lancache/logs/Keys/arenanetworks.log keys_range buffer=128k flush=1m;
 	error_log /srv/lancache/logs/Errors/arenanetworks.log;
 	

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -149,8 +149,10 @@ server:
         local-data: "11df-eu-lb.apr-11df.edgecastdns.net. 600 IN A lc-host-gog"
         
     ## Arena networks °|-lc-host-vint:10
-        local-zone: "arenanetworks.com." redirect
-        local-data: "arenanetworks.com. 600 IN A lc-host-arena"
+        local-zone: "arenanetworks.com." transparent
+        local-data: "assetcdn.101.arenanetworks.com. 600 IN A lc-host-arena"
+        local-data: "assetcdn.102.arenanetworks.com. 600 IN A lc-host-arena"
+        local-data: "assetcdn.103.arenanetworks.com. 600 IN A lc-host-arena"
 
     ## Wargaming °|-lc-host-vint:11
         local-zone: "wargaming.net." transparent


### PR DESCRIPTION
Disable IPv6 lookups for upstream DNS resolution (Noticed issue with Microsoft cache)
Fix the access log name for Arena Networks
Fix DNS for Arena Networks to exclude auth servers
Auto set the number of worker processes based on CPU count