### PR TITLE
Update interfaces

### DIFF
--- a/interfaces
+++ b/interfaces
@@ -67,19 +67,19 @@ auto lc-host-vint:10
     
 # IP used for Apple caching
 auto lc-host-vint:11
-    iface lc-host-vint:13 inet static
+    iface lc-host-vint:11 inet static
     address lc-host-apple
     netmask lc-host-netmask 
     
 # IP used for WarGaming caching
 auto lc-host-vint:12
-    iface lc-host-vint:11 inet static
+    iface lc-host-vint:12 inet static
     address lc-host-wargaming
     netmask lc-host-netmask
 
 # IP used for Uplay caching
 auto lc-host-vint:13
-    iface lc-host-vint:12 inet static
+    iface lc-host-vint:13 inet static
     address lc-host-uplay
     netmask lc-host-netmask 
     


### PR DESCRIPTION
When changing the order, I forgot to fix/edit the numbers in conf-sections. Now auto-lc-host-vint matches iface lc-host-vint again.
Shouldn't be crittical, as will be replaced by real IPs, but looks confusing.