### PR TITLE
Update lancache-riot.conf

### DIFF
--- a/conf/vhosts-enabled/lancache-riot.conf
+++ b/conf/vhosts-enabled/lancache-riot.conf
@@ -15,7 +15,7 @@ location ~ ^/releases/live/solutions/.*/releaselisting {
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http:///$host$request_uri;
+        proxy_pass http://$host$request_uri;
     }
 
     location / {


### PR DESCRIPTION
League Client was failing to initialize properly when requesting the "/releases/live/solutions/.*/releaselisting" path. This is due to the additional forward slash on the proxy_pass directive.