### PR TITLE
Update unbound.conf

### DIFF
--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -361,7 +361,7 @@ server:
         	local-data: "dn.sea.playblackdesert.com.edgesuite.net. 600 IN A lc-host-pearlabyss"
 
 
-	## pearlabyss °|-lc-host-vint:17
+	## gaijin °|-lc-host-vint:18
 		local-zone: "gaijin.s-1.clients.cdnnow.ru." redirect
 		local-data: "gaijin.s-1.clients.cdnnow.ru. 600 IN A lc-host-gaijin"
 		local-zone: "gaijin.s-2.clients.cdnnow.ru." redirect


### PR DESCRIPTION
Since you named the IP-dummy "lc-host-gaijin" in the last section, I assume the comment should also call it gaijin and 'link' to the proper interface 18.

Sorry, didn't know I'm making different patches for one topic (gaijin...)