### PR TITLE
Update "lancache" init script

### DIFF
--- a/init.d/lancache
+++ b/init.d/lancache
@@ -12,7 +12,7 @@
 ### END INIT INFO
  
 PATH=/opt/bin:/opt/sbin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/local/nginx/sbin/nginx
+DAEMON=/usr/local/sbin/nginx
 NAME=lancache
 # DESC=Caching Games Locally
  


### PR DESCRIPTION
Path to nginx didn't fit:
I followed instructions on compiling and "make install" nginx, which leaded to be put into /usr/local/sbin/nginx instead of /usr/local/nginx/sbin/nginx.
Tested on: Debian 9.5.0 and nginx nginx-1.14.0.